### PR TITLE
Integrate companion utility and streamline commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ The terminal, invoked after login, serves as the shell for Arianna Core.
 	•	Logs: Each session logs to /arianna_core/log/, stamped with UTC.
 	•	max_log_files option in ~/.letsgo/config to limit disk usage.
 	•	History: /arianna_core/log/history persists command history, loaded at startup, updated on exit.
-	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /summarize, /search, /color, /help.
+	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /summarize, /search, /xplaine, /xplaineoff, /help.
 	•	/status: Reports CPU cores, uptime (from /proc/uptime), and current IP.
 	•	/summarize: Searches logs (with regex), prints last five matches; --history searches command history; /search <pattern> finds all matches.
 	•	/time: Prints current UTC.
 	•	/run : Executes shell command.
-	•	/help: Lists verbs.
-	•	/color on|off: Toggles colored output.
+        •       /help: Lists verbs.
+        •       /xplaine: ask companion.
+        •       /xplaineoff: companion off.
 	•	Unrecognized input: echoed back.
 	•	Structure ready for more advanced NLP (text hooks dispatch to remote models).
 

--- a/bridge.py
+++ b/bridge.py
@@ -402,9 +402,9 @@ async def start_bot() -> None:
     persistence = PicklePersistence(filepath=persistence_path)
     application = ApplicationBuilder().token(token).persistence(persistence).build()
     commands = [
-        BotCommand(cmd[1:], desc.lower()) for cmd, (_, desc) in CORE_COMMANDS.items()
+        BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()
     ]
-    commands.append(BotCommand("history", "show command history"))
+    commands.append(BotCommand("history", "command history"))
     await application.bot.set_my_commands(commands)
     terminal_url = os.getenv("WEB_TERMINAL_URL", "").strip()
     if terminal_url:

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -145,8 +145,9 @@ def test_clear_command_registered(monkeypatch):
         called["cmd"] = cmd
 
     monkeypatch.setattr(os, "system", fake_system)
-    asyncio.run(handlers["/clear"]("/clear"))
+    out, _ = asyncio.run(handlers["/clear"]("/clear"))
     assert called["cmd"] == "clear"
+    assert out == "Cleared."
 
 
 def test_help_lists_command_descriptions():
@@ -156,9 +157,9 @@ def test_help_lists_command_descriptions():
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/clear" in output
-    assert "clear the terminal screen" in output
+    assert "clear the terminal" in output
     assert "/history" in output
-    assert "show command history" in output
+    assert "command history" in output
 
 
 def test_help_specific_command():
@@ -198,12 +199,3 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
-
-
-def test_color_setting_persisted(tmp_path, monkeypatch):
-    config = tmp_path / "config"
-    monkeypatch.setattr(letsgo, "CONFIG_PATH", config)
-    monkeypatch.setattr(letsgo, "SETTINGS", letsgo.Settings())
-    monkeypatch.setattr(letsgo, "USE_COLOR", True)
-    asyncio.run(letsgo.handle_color("/color off"))
-    assert "use_color=False" in config.read_text()


### PR DESCRIPTION
## Summary
- log all terminal activity through Tommy and store it in SQLite
- add `/xplaine` and `/xplaineoff` companion commands and update menu descriptions
- remove `/color` command and make `/clear` report "Cleared."

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964202c6948329b211f087f106df74