### PR TITLE
Add bash command and auto-format Python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,17 @@ The terminal, invoked after login, serves as the shell for Arianna Core.
 	•	Logs: Each session logs to /arianna_core/log/, stamped with UTC.
 	•	max_log_files option in ~/.letsgo/config to limit disk usage.
 	•	History: /arianna_core/log/history persists command history, loaded at startup, updated on exit.
-	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /summarize, /search, /xplaine, /xplaineoff, /help.
+	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /bash, /py, /summarize, /search, /xplaine, /xplaineoff, /help.
 	•	/status: Reports CPU cores, uptime (from /proc/uptime), and current IP.
 	•	/summarize: Searches logs (with regex), prints last five matches; --history searches command history; /search <pattern> finds all matches.
 	•	/time: Prints current UTC.
 	•	/run : Executes shell command.
+        •       /bash: Runs a Bash script.
+        •       /py: Executes Python code; plain Python snippets are auto-formatted and run even without the /py prefix.
         •       /help: Lists verbs.
         •       /xplaine: ask companion.
         •       /xplaineoff: companion off.
-	•	Unrecognized input: echoed back.
+        •       Unrecognized input that is not Python code: echoed back.
 	•	Structure ready for more advanced NLP (text hooks dispatch to remote models).
 
 Tommy

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -208,3 +208,16 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
+
+
+def test_handle_bash_executes_script():
+    output, colored = asyncio.run(letsgo.handle_bash("/bash echo hi"))
+    assert output.startswith("hi")
+    assert colored is None
+
+
+def test_format_and_detect_python():
+    formatted = letsgo.format_python("x=1")
+    assert "x = 1" in formatted
+    assert letsgo.looks_like_python("print('ok')")
+    assert not letsgo.looks_like_python("ls")


### PR DESCRIPTION
## Summary
- support executing Bash scripts via new `/bash` command
- auto-format Python snippets and detect plain Python messages
- document shell and Python enhancements and add unit tests

## Testing
- `black --check letsgo.py tests/test_letsgo.py`
- `pytest`
- `./run-tests.sh` *(fails: flake8: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fc6c3ce48329934bc261bb4f9f21