### PR TITLE
Add archive extraction helper and tests

### DIFF
--- a/arianna_utils/archive.py
+++ b/arianna_utils/archive.py
@@ -1,0 +1,36 @@
+import os
+import zipfile
+import tarfile
+
+
+def _is_within_directory(directory: str, target: str) -> bool:
+    """Return True if target is inside directory."""
+    abs_directory = os.path.abspath(directory)
+    abs_target = os.path.abspath(target)
+    return os.path.commonprefix([abs_directory, abs_target]) == abs_directory
+
+
+def safe_extract(archive, path: str = ".", members=None, *, numeric_owner: bool = False) -> None:
+    """Safely extract ``archive`` to ``path``.
+
+    Supports :class:`zipfile.ZipFile` and :class:`tarfile.TarFile` objects and
+    prevents path traversal vulnerabilities by verifying extracted paths.
+    """
+    if isinstance(archive, zipfile.ZipFile):
+        infos = members or archive.infolist()
+        for info in infos:
+            name = info.filename if isinstance(info, zipfile.ZipInfo) else str(info)
+            dest = os.path.join(path, name)
+            if not _is_within_directory(path, dest):
+                raise Exception("Attempted Path Traversal in Zip File")
+        archive.extractall(path, members=members)
+    elif isinstance(archive, tarfile.TarFile):
+        infos = members or archive.getmembers()
+        for info in infos:
+            name = info.name if isinstance(info, tarfile.TarInfo) else str(info)
+            dest = os.path.join(path, name)
+            if not _is_within_directory(path, dest):
+                raise Exception("Attempted Path Traversal in Tar File")
+        archive.extractall(path, members=members, numeric_owner=numeric_owner)
+    else:  # pragma: no cover - unsupported archive types
+        raise TypeError(f"Unsupported archive type: {type(archive)}")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,58 @@
+import os
+import tarfile
+import zipfile
+import tempfile
+import io
+import pytest
+
+from arianna_utils.archive import safe_extract
+
+
+def _create_zip(files):
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.zip')
+    with zipfile.ZipFile(tmp.name, 'w') as z:
+        for name, data in files.items():
+            z.writestr(name, data)
+    return tmp
+
+
+def _create_tar(files):
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.tar')
+    with tarfile.open(tmp.name, 'w') as t:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            t.addfile(info, io.BytesIO(data.encode()))
+    return tmp
+
+
+def test_safe_extract_zip(tmp_path):
+    tmp = _create_zip({'a.txt': 'hello'})
+    with zipfile.ZipFile(tmp.name) as z:
+        safe_extract(z, tmp_path)
+    assert (tmp_path / 'a.txt').read_text() == 'hello'
+    os.unlink(tmp.name)
+
+
+def test_safe_extract_zip_traversal(tmp_path):
+    tmp = _create_zip({'../evil.txt': 'bad'})
+    with zipfile.ZipFile(tmp.name) as z:
+        with pytest.raises(Exception):
+            safe_extract(z, tmp_path)
+    os.unlink(tmp.name)
+
+
+def test_safe_extract_tar(tmp_path):
+    tmp = _create_tar({'b.txt': 'world'})
+    with tarfile.open(tmp.name) as t:
+        safe_extract(t, tmp_path)
+    assert (tmp_path / 'b.txt').read_text() == 'world'
+    os.unlink(tmp.name)
+
+
+def test_safe_extract_tar_traversal(tmp_path):
+    tmp = _create_tar({'../evil.txt': 'bad'})
+    with tarfile.open(tmp.name) as t:
+        with pytest.raises(Exception):
+            safe_extract(t, tmp_path)
+    os.unlink(tmp.name)


### PR DESCRIPTION
## Summary
- add `safe_extract` to prevent path traversal in archive handling
- cover zip and tar extraction with tests

## Testing
- `flake8` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0a3fa6c5083299c9cd3fe0c9e332f