### PR TITLE
Handle Telegram file uploads automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Future development of the agent aims to expand its capabilities: we plan to add 
 
 ## Recent Changes
 
-- Integrated `arianna_utils.context_neural_processor` with `letsgo.py` via the `/file` command for direct file ingestion.
+- Integrated `arianna_utils.context_neural_processor` with `letsgo.py` to ingest files automatically when they're uploaded.
 - Granted Tommy terminal access and required a mood script after every message.
 - Documentation now frames the system as a platform for emergent agents sharing a SQLite resonance channel.
 


### PR DESCRIPTION
## Summary
- Process uploaded Telegram files through the internal `/file` command automatically
- Hide `/file` from bot command menus and help text
- Update documentation for automatic file ingestion

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a56b66e4832982287e6d77107301