### PR TITLE
feat: enhance resonance metadata and analysis

### DIFF
--- a/tests/test_resonance.py
+++ b/tests/test_resonance.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from tommy import tommy
+from tommy.tommy_logic import analyze_resonance
 
 
 def test_resonance_records_last_five(monkeypatch, tmp_path):
@@ -17,8 +18,27 @@ def test_resonance_records_last_five(monkeypatch, tmp_path):
         tommy.log_event(f"user:msg{i}")
     tommy.update_resonance()
     conn = sqlite3.connect(tommy.RESONANCE_DB_PATH)
-    cur = conn.execute("SELECT summary FROM resonance ORDER BY rowid DESC LIMIT 1")
-    summary = cur.fetchone()[0]
+    cur = conn.execute(
+        "SELECT summary, role, sentiment, snapshots FROM resonance ORDER BY rowid DESC LIMIT 1"
+    )
+    summary, role, sentiment, snaps = cur.fetchone()
     conn.close()
     assert "msg2" in summary and "msg6" in summary
     assert "msg1" not in summary
+    assert role == "guardian"
+    assert sentiment in {"neutral", "positive", "negative"}
+    assert isinstance(snaps, str)
+
+
+def test_analyze_resonance(monkeypatch, tmp_path):
+    monkeypatch.setattr(tommy, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(tommy, "DB_PATH", tmp_path / "tommy.sqlite3")
+    monkeypatch.setattr(tommy, "RESONANCE_DB_PATH", tmp_path / "resonance.sqlite3")
+    tommy._init_db()
+    tommy._init_resonance_db()
+    tommy.log_event("user:all good")
+    tommy.update_resonance()
+    tommy.log_event("user:error happened")
+    tommy.update_resonance()
+    report = analyze_resonance(1)
+    assert "2 entries" in report

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -40,7 +40,8 @@ def test_snapshot_flow(monkeypatch, tmp_path):
     tommy.update_resonance()
     with sqlite3.connect(tommy.RESONANCE_DB_PATH, timeout=30) as conn:
         cur = conn.execute(
-            "SELECT summary FROM resonance ORDER BY rowid DESC LIMIT 1"
+            "SELECT summary, snapshots FROM resonance ORDER BY rowid DESC LIMIT 1"
         )
-        summary = cur.fetchone()[0]
+        summary, snaps = cur.fetchone()
     assert "predicted" in summary
+    assert "2024-05-02" in snaps

--- a/tommy/tommy_logic.py
+++ b/tommy/tommy_logic.py
@@ -128,3 +128,39 @@ def predict_tomorrow(snapshot_today: Snapshot) -> str:
             (prediction, snapshot_today.date.strftime("%Y-%m-%d")),
         )
     return prediction
+
+
+def analyze_resonance(window: int) -> str:
+    """Analyze resonance history over the given window in days.
+
+    Parameters
+    ----------
+    window:
+        Number of days to look back for resonance events.
+
+    Returns
+    -------
+    str
+        Short textual report summarizing sentiment trend and anomalies.
+    """
+
+    cutoff = datetime.now() - timedelta(days=window)
+    with sqlite3.connect(_tommy.RESONANCE_DB_PATH, timeout=30) as conn:
+        cur = conn.execute(
+            "SELECT ts, sentiment FROM resonance WHERE ts >= ? ORDER BY ts",
+            (cutoff.isoformat(),),
+        )
+        rows = cur.fetchall()
+    if not rows:
+        return "No resonance data."
+    total = len(rows)
+    pos = sum(1 for _, s in rows if s == "positive")
+    neg = sum(1 for _, s in rows if s == "negative")
+    neu = total - pos - neg
+    trend = "positive" if pos >= neg else "negative"
+    anomaly = "Anomaly detected" if neg > pos * 2 else "Stable"
+    return (
+        f"{total} entries in last {window} days: "
+        f"{pos} positive, {neg} negative, {neu} neutral. "
+        f"Trend {trend}. {anomaly}."
+    )


### PR DESCRIPTION
## Summary
- track role, sentiment, and snapshot links when updating resonance
- add `analyze_resonance(window)` to report trends and anomalies
- expand tests for resonance metadata and snapshot linkage

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bfa1c93c8329a473b6da23952669