### PR TITLE
feat: retain context after file processing

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -29,7 +29,7 @@ import shlex
 import textwrap
 import ast
 from tommy import tommy
-from arianna_utils.context_neural_processor import parse_and_store_file
+from tommy.tommy_logic import process_file_with_context
 
 _NO_COLOR_FLAG = "--no-color"
 USE_COLOR = (
@@ -488,7 +488,7 @@ async def handle_file(user: str) -> Tuple[str, str | None]:
         reply = "Usage: /file <path>"
         return reply, reply
     try:
-        result = await parse_and_store_file(path)
+        result = await process_file_with_context(path)
     except Exception as e:
         result = f"Error: {e}"
     return result, result

--- a/tests/test_tommy_file.py
+++ b/tests/test_tommy_file.py
@@ -1,0 +1,41 @@
+import asyncio
+import sqlite3
+from pathlib import Path
+
+from tommy.tommy_logic import process_file_with_context
+from tommy import tommy as t
+from arianna_utils import context_neural_processor as cnp
+from arianna_utils.vector_store import SQLiteVectorStore
+
+
+class _DummyESN:
+    def update(self, text: str, pulse: float) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def test_process_file_with_context_logs(tmp_path, monkeypatch):
+    # Redirect Tommy's databases to temporary locations
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+    monkeypatch.setattr(t, "LOG_DIR", log_dir)
+    monkeypatch.setattr(t, "DB_PATH", log_dir / "tommy.sqlite3")
+    monkeypatch.setattr(t, "RESONANCE_DB_PATH", log_dir / "resonance.sqlite3")
+    t._init_db()
+    t._init_resonance_db()
+
+    # Prepare context processor cache and dependencies
+    monkeypatch.setattr(cnp, "CACHE_DB", tmp_path / "cache.db")
+    cnp.init_cache_db()
+    monkeypatch.setattr(cnp, "esn", _DummyESN())
+
+    sample = tmp_path / "sample.txt"
+    sample.write_text("hello world")
+
+    engine = SQLiteVectorStore(tmp_path / "vectors.db")
+    result = asyncio.run(process_file_with_context(str(sample), engine=engine))
+
+    assert "hello world" in result
+
+    with sqlite3.connect(t.DB_PATH, timeout=30) as conn:
+        rows = conn.execute("SELECT message FROM events").fetchall()
+    assert any("Processed" in r[0] for r in rows)

--- a/tommy/tommy_logic.py
+++ b/tommy/tommy_logic.py
@@ -195,3 +195,32 @@ def analyze_resonance(window: int) -> str:
         f"{pos} positive, {neg} negative, {neu} neutral. "
         f"Trend {trend}. {anomaly}."
     )
+
+
+async def process_file_with_context(path: str, engine=None) -> str:
+    """Process a file and record its summary for Tommy.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the file.
+    engine:
+        Optional :class:`~arianna_utils.vector_store.SQLiteVectorStore` instance
+        to use for embeddings.
+
+    Returns
+    -------
+    str
+        Full result from ``parse_and_store_file``.
+    """
+
+    from arianna_utils.context_neural_processor import parse_and_store_file
+
+    result = await parse_and_store_file(path, engine=engine)
+
+    match = re.search(r"Summary: (.*)", result)
+    summary = match.group(1).splitlines()[0] if match else ""
+    message = f"Processed {path}: {summary[:200]}" if summary else f"Processed {path}"
+    _tommy.log_event(message)
+    _tommy.update_resonance()
+    return result


### PR DESCRIPTION
## Summary
- let Tommy log and remember files processed via the neural processor
- wire /file command to the new logic and test logging behavior

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8 black` *(fails: Could not find a version that satisfies the requirement flake8; No matching distribution found)*
- `black --check tommy/tommy_logic.py letsgo.py tests/test_tommy_file.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi; No matching distribution found)*
- `pytest tests/test_context_processor.py tests/test_letsgo.py tests/test_tommy_file.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3cc4ed48329aa8c983f42abe40f