### PR TITLE
Add upload size limit for WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The bridge and HTTP server require several variables to be set before starting `
 - `API_TOKEN` – shared secret for API requests and WebSocket connections
 - `TELEGRAM_TOKEN` – token used by the Telegram agent
 - `PORT` – port for the HTTP server (defaults to `8000`)
+- `MAX_UPLOAD_SIZE` – maximum allowed size in bytes for WebSocket uploads (defaults to `10485760`)
 
 ---
 

--- a/tests/test_upload_ws.py
+++ b/tests/test_upload_ws.py
@@ -1,0 +1,19 @@
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+import bridge
+
+
+def test_upload_ws_respects_max_size(tmp_path, monkeypatch):
+    monkeypatch.setenv("API_TOKEN", "secret")
+    monkeypatch.setenv("MAX_UPLOAD_SIZE", "5")
+    importlib.reload(bridge)
+    bridge.UPLOAD_DIR = str(tmp_path)
+    client = TestClient(bridge.app)
+    with client.websocket_connect("/upload?token=secret&name=data.bin") as ws:
+        ws.send_bytes(b"abcdef")
+        with pytest.raises(WebSocketDisconnect):
+            ws.receive_bytes()
+    assert not (tmp_path / "data.bin").exists()


### PR DESCRIPTION
## Summary
- enforce a configurable upload size limit for `/upload` websocket
- document `MAX_UPLOAD_SIZE` environment variable
- add regression test for exceeding upload size

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b0e424ded08329bfc0de6073ed311c