### PR TITLE
Add missing dependencies to project requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,7 @@ pillow
 pandas
 pyyaml
 rarfile
+openai
+black
+flake8
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ pillow==10.4.0
 pandas==2.2.2
 pyyaml==6.0.1
 rarfile==4.2
+openai==1.40.6
+black==24.4.2
+flake8==7.0.0
+pytest==8.2.2


### PR DESCRIPTION
## Summary
- include runtime OpenAI client and development tools in `requirements.in`
- pin OpenAI, Black, Flake8, and Pytest in `requirements.txt`

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eccc900883298a7feaa15e3ae0f5