### PR TITLE
Remove Telegram menu button linking to Tommy

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -21,8 +21,6 @@ from telegram import (
     BotCommand,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
-    MenuButtonWebApp,
-    WebAppInfo,
 )
 from telegram.ext import (
     ApplicationBuilder,
@@ -473,11 +471,6 @@ async def start_bot() -> None:
     ]
     commands.append(BotCommand("history", "command history"))
     await application.bot.set_my_commands(commands)
-    terminal_url = os.getenv("WEB_TERMINAL_URL", "").strip()
-    if terminal_url:
-        await application.bot.set_chat_menu_button(
-            MenuButtonWebApp(text="Terminal", web_app=WebAppInfo(url=terminal_url))
-        )
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("history", history_command))


### PR DESCRIPTION
## Summary
- Delete Telegram menu button that launched the web terminal
- Drop unused `MenuButtonWebApp` and `WebAppInfo` imports

## Testing
- `black --check bridge.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install flake8 black pytest` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ed8e98008329a3344c270b3f9fd3