### PR TITLE
fix: migrate Tommy resonance DB schema

### DIFF
--- a/tommy/tommy.py
+++ b/tommy/tommy.py
@@ -29,6 +29,11 @@ def _init_resonance_db() -> None:
             "ts TEXT, agent TEXT, role TEXT, sentiment TEXT, snapshots TEXT, summary TEXT"
             ")"
         )
+        cur = conn.execute("PRAGMA table_info(resonance)")
+        cols = {row[1] for row in cur.fetchall()}
+        for col in ["role", "sentiment", "snapshots", "summary"]:
+            if col not in cols:
+                conn.execute(f"ALTER TABLE resonance ADD COLUMN {col} TEXT")
 
 
 _init_db()


### PR DESCRIPTION
## Summary
- ensure Tommy's resonance database adds missing columns if schema is outdated

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b0ee75e0cc8329ba9fffebacb6242a