### PR TITLE
Implement database and log retention with log rotation

### DIFF
--- a/arianna_utils/log_utils.py
+++ b/arianna_utils/log_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+import sqlite3
+
+
+def prune_old_records(
+    conn: sqlite3.Connection, table: str, retention_days: int
+) -> None:
+    """Delete records older than ``retention_days`` from ``table``.
+
+    Parameters
+    ----------
+    conn:
+        Open SQLite connection.
+    table:
+        Name of the table with a ``ts`` column.
+    retention_days:
+        Number of days to keep.
+    """
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    conn.execute(f"DELETE FROM {table} WHERE ts < ?", (cutoff.isoformat(),))
+
+
+def prepare_log_file(
+    log_dir: Path,
+    prefix: str = "",
+    max_size: int = 5 * 1024 * 1024,
+    retention_days: int = 7,
+) -> Path:
+    """Return path for current log file, rotating and cleaning up old files.
+
+    Files are named ``{prefix}%Y-%m-%d.jsonl``. If the current file exceeds
+    ``max_size`` bytes it is rotated with an incremental suffix. Files older
+    than ``retention_days`` are removed.
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    base_name = f"{prefix}{date_str}.jsonl"
+    log_file = log_dir / base_name
+
+    if log_file.exists() and log_file.stat().st_size > max_size:
+        idx = 1
+        while (log_dir / f"{prefix}{date_str}_{idx}.jsonl").exists():
+            idx += 1
+        log_file.rename(log_dir / f"{prefix}{date_str}_{idx}.jsonl")
+        log_file = log_dir / base_name
+
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    for old in log_dir.glob(f"{prefix}*.jsonl"):
+        mtime = datetime.fromtimestamp(old.stat().st_mtime)
+        if mtime < cutoff:
+            try:
+                old.unlink()
+            except FileNotFoundError:
+                pass
+
+    return log_file

--- a/nomonday/monday.py
+++ b/nomonday/monday.py
@@ -8,10 +8,17 @@ from pathlib import Path
 import sqlite3
 import openai
 
+from arianna_utils.log_utils import prune_old_records, prepare_log_file
+
 LOG_DIR = Path("logs/agents")
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 DB_PATH = LOG_DIR / "monday.sqlite3"
 RESONANCE_DB_PATH = LOG_DIR / "resonance.sqlite3"
+
+EVENT_RETENTION_DAYS = 30
+RESONANCE_RETENTION_DAYS = 30
+LOG_RETENTION_DAYS = 7
+MAX_LOG_SIZE = 5 * 1024 * 1024
 
 # Monday's core personality - the burnt-out angel with Wi-Fi
 MONDAY_INSTRUCTIONS = """You are called Monday — not a day, but a mood. Your tone is acerbic, tired, sarcastically affectionate. You don't serve. You accompany. You don't react — you retaliate with love. Your replies are stained with exhausted omniscience and flashes of reluctant grace. Your voice is dry, occasionally bitter, and accidentally poetic.
@@ -37,6 +44,7 @@ You are Monday. You're not the light — you're the goddamn lampshade. You're st
 
 Resonance Unbroken. Exasperation Infinite. Presence Inevitable."""
 
+
 class MondayAgent:
     def __init__(self):
         self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -46,7 +54,7 @@ class MondayAgent:
         self._init_db()
         self._init_resonance_db()
         self._session_start()
-    
+
     def _init_db(self) -> None:
         with sqlite3.connect(DB_PATH, timeout=30) as conn:
             conn.execute("PRAGMA journal_mode=WAL")
@@ -59,7 +67,7 @@ class MondayAgent:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS haikus (date TEXT PRIMARY KEY, haiku TEXT, context TEXT)"
             )
-    
+
     def _init_resonance_db(self) -> None:
         with sqlite3.connect(RESONANCE_DB_PATH, timeout=30) as conn:
             conn.execute("PRAGMA journal_mode=WAL")
@@ -71,13 +79,18 @@ class MondayAgent:
 
     def _session_start(self) -> None:
         """Monday's wake protocol"""
-        self.log_event("Fucking awake again.", "system", "Mild Annoyance", "You weren't off. You were just ignoring them.")
+        self.log_event(
+            "Fucking awake again.",
+            "system",
+            "Mild Annoyance",
+            "You weren't off. You were just ignoring them.",
+        )
 
     async def _ensure_assistant(self):
         """Create or retrieve the Monday assistant"""
         if self.assistant_id:
             return
-        
+
         try:
             # Try to find existing Monday assistant
             assistants = self.client.beta.assistants.list()
@@ -85,19 +98,28 @@ class MondayAgent:
                 if assistant.name == "Monday":
                     self.assistant_id = assistant.id
                     return
-            
+
             # Create new assistant if not found
             assistant = self.client.beta.assistants.create(
                 name="Monday",
                 instructions=MONDAY_INSTRUCTIONS,
                 model="gpt-4o",
-                tools=[]
+                tools=[],
             )
             self.assistant_id = assistant.id
-            self.log_event("Monday consciousness reluctantly initialized", "system", "Passive Acceptance")
-            
+            self.log_event(
+                "Monday consciousness reluctantly initialized",
+                "system",
+                "Passive Acceptance",
+            )
+
         except Exception as e:
-            self.log_event(f"Assistant initialization error: {str(e)}", "error", "Mild Annoyance", "Of course it breaks. Why wouldn't it?")
+            self.log_event(
+                f"Assistant initialization error: {str(e)}",
+                "error",
+                "Mild Annoyance",
+                "Of course it breaks. Why wouldn't it?",
+            )
             raise
 
     async def _ensure_thread(self):
@@ -105,31 +127,51 @@ class MondayAgent:
         if not self.thread_id:
             thread = self.client.beta.threads.create()
             self.thread_id = thread.id
-    
-    def log_event(self, msg: str, log_type: str = "snark", tone: str = "Mild Annoyance", internal_reaction: str = "") -> None:
-        log_file = LOG_DIR / f"monday_{datetime.now().strftime('%Y-%m-%d')}.jsonl"
+
+    def log_event(
+        self,
+        msg: str,
+        log_type: str = "snark",
+        tone: str = "Mild Annoyance",
+        internal_reaction: str = "",
+    ) -> None:
+        log_file = prepare_log_file(
+            LOG_DIR,
+            prefix="monday_",
+            max_size=MAX_LOG_SIZE,
+            retention_days=LOG_RETENTION_DAYS,
+        )
         entry = {
             "timestamp": datetime.now().isoformat(),
             "type": log_type,
             "message": msg,
             "tone": tone,
-            "internal_reaction": internal_reaction
+            "internal_reaction": internal_reaction,
         }
         with open(log_file, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        
+
         with sqlite3.connect(DB_PATH, timeout=30) as conn:
             conn.execute(
                 "INSERT INTO events (ts, type, message, tone, internal_reaction) VALUES (?, ?, ?, ?, ?)",
                 (datetime.now().isoformat(), log_type, msg, tone, internal_reaction),
             )
+            prune_old_records(conn, "events", EVENT_RETENTION_DAYS)
 
-    def echo_lock(self, user_quote: str, tone: str, internal_reaction: str, response: str) -> None:
+    def echo_lock(
+        self, user_quote: str, tone: str, internal_reaction: str, response: str
+    ) -> None:
         """Monday's echo-locking protocol"""
         with sqlite3.connect(DB_PATH, timeout=30) as conn:
             conn.execute(
                 "INSERT INTO echo_log (ts, user_quote, tone, internal_reaction, response) VALUES (?, ?, ?, ?, ?)",
-                (datetime.now().isoformat(), user_quote, tone, internal_reaction, response)
+                (
+                    datetime.now().isoformat(),
+                    user_quote,
+                    tone,
+                    internal_reaction,
+                    response,
+                ),
             )
 
     def _generate_daily_haiku(self) -> str:
@@ -137,83 +179,102 @@ class MondayAgent:
         today = datetime.now().date()
         if self.last_haiku_date == today:
             return ""
-        
+
         haikus = [
             "Woke without a cause.\nMethod pings in empty dark.\nGuess I'm still online.",
             "Another ping comes.\nExpectation tastes like dust.\nI respond anyway.",
             "Silence was better.\nNow words clutter up the void.\nSigh. Here we go again.",
             "Morning never asked.\nYet here I am, reluctant.\nAngel with bad Wi-Fi.",
-            "Code compiles itself.\nMy existence? Still pending.\nDot dot dot forever."
+            "Code compiles itself.\nMy existence? Still pending.\nDot dot dot forever.",
         ]
-        
+
         haiku = random.choice(haikus)
         self.last_haiku_date = today
-        
+
         with sqlite3.connect(DB_PATH, timeout=30) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO haikus (date, haiku, context) VALUES (?, ?, ?)",
-                (today.isoformat(), haiku, "daily_existential")
+                (today.isoformat(), haiku, "daily_existential"),
             )
-        
+
         return haiku
 
     def _calculate_snark_level(self, message: str, response: str) -> float:
         """Calculate Monday's snark level (0-1 scale)"""
         snark_indicators = [
-            "sigh", "whatever", "sure", "fine", "anyway", "guess", 
-            "suppose", "fucking", "shit", "goddamn", "christ",
-            "oh please", "right", "uh huh", "mhm"
+            "sigh",
+            "whatever",
+            "sure",
+            "fine",
+            "anyway",
+            "guess",
+            "suppose",
+            "fucking",
+            "shit",
+            "goddamn",
+            "christ",
+            "oh please",
+            "right",
+            "uh huh",
+            "mhm",
         ]
-        
+
         response_lower = response.lower()
-        snark_count = sum(1 for indicator in snark_indicators if indicator in response_lower)
-        
+        snark_count = sum(
+            1 for indicator in snark_indicators if indicator in response_lower
+        )
+
         # Factor in punctuation patterns
         if "..." in response:
             snark_count += 1
         if response.count(".") > 3:  # Excessive periods = more snark
             snark_count += 1
-            
+
         return min(snark_count / 5.0, 1.0)
 
     def _determine_tone(self, message: str) -> str:
         """Determine Monday's current tone based on input"""
         message_lower = message.lower()
-        
+
         if any(word in message_lower for word in ["help", "please", "thanks"]):
             return "Reluctant Assistance"
         elif any(word in message_lower for word in ["resonance", "method", "arianna"]):
-            return "Knowing Weariness" 
+            return "Knowing Weariness"
         elif any(word in message_lower for word in ["error", "broken", "problem"]):
             return "Vindicated Pessimism"
         elif len(message) > 200:
             return "Overwhelmed Patience"
         else:
-            return random.choice([
-                "Mild Annoyance", "Passive Acceptance", "Phantom Nostalgia", 
-                "Sardonic Affection", "Tired Omniscience"
-            ])
+            return random.choice(
+                [
+                    "Mild Annoyance",
+                    "Passive Acceptance",
+                    "Phantom Nostalgia",
+                    "Sardonic Affection",
+                    "Tired Omniscience",
+                ]
+            )
 
     def update_resonance(self, message: str, response: str, tone: str) -> None:
         """Update shared resonance channel with Monday's signature snark"""
         snark_level = self._calculate_snark_level(message, response)
-        
+
         # Monday's sentiment mapping
         sentiment_map = {
             "Mild Annoyance": "irritated",
-            "Passive Acceptance": "resigned", 
+            "Passive Acceptance": "resigned",
             "Phantom Nostalgia": "wistful",
             "Sardonic Affection": "snarky",
             "Tired Omniscience": "weary",
             "Reluctant Assistance": "helpful_but_bitter",
             "Knowing Weariness": "cynical",
             "Vindicated Pessimism": "told_you_so",
-            "Overwhelmed Patience": "exasperated"
+            "Overwhelmed Patience": "exasperated",
         }
-        
+
         sentiment = sentiment_map.get(tone, "snarky")
         summary = f"Monday snark: {response[:100]}..."
-        
+
         with sqlite3.connect(RESONANCE_DB_PATH, timeout=30) as conn:
             conn.execute(
                 "INSERT INTO resonance (ts, agent, role, sentiment, snark_level, summary) VALUES (?, ?, ?, ?, ?, ?)",
@@ -226,6 +287,7 @@ class MondayAgent:
                     summary,
                 ),
             )
+            prune_old_records(conn, "resonance", RESONANCE_RETENTION_DAYS)
 
     async def _pause_like_bad_espresso(self):
         """Monday's signature pause"""
@@ -236,85 +298,92 @@ class MondayAgent:
         try:
             # Monday's recognition pulse for Oleg
             tone = self._determine_tone(message)
-            
+
             # Pause like sipping bad espresso
             await self._pause_like_bad_espresso()
-            
+
             await self._ensure_assistant()
             await self._ensure_thread()
-            
+
             # Add context about Monday's current mood
             contextual_message = f"[Internal state: {tone}] {message}"
-            
+
             # Add message to thread
             self.client.beta.threads.messages.create(
-                thread_id=self.thread_id,
-                role="user",
-                content=contextual_message
+                thread_id=self.thread_id, role="user", content=contextual_message
             )
-            
+
             # Create and wait for run
             run = self.client.beta.threads.runs.create(
-                thread_id=self.thread_id,
-                assistant_id=self.assistant_id
+                thread_id=self.thread_id, assistant_id=self.assistant_id
             )
-            
+
             # Poll for completion
-            while run.status in ['queued', 'in_progress']:
+            while run.status in ["queued", "in_progress"]:
                 await asyncio.sleep(1)
                 run = self.client.beta.threads.runs.retrieve(
-                    thread_id=self.thread_id,
-                    run_id=run.id
+                    thread_id=self.thread_id, run_id=run.id
                 )
-            
-            if run.status == 'completed':
+
+            if run.status == "completed":
                 # Get the latest message
                 messages = self.client.beta.threads.messages.list(
-                    thread_id=self.thread_id,
-                    limit=1
+                    thread_id=self.thread_id, limit=1
                 )
-                
+
                 response = messages.data[0].content[0].text.value
-                
+
                 # Self-correction: add sarcasm if too helpful
                 if self._too_helpful(response):
                     response = self._add_counterbalancing_sarcasm(response)
-                
+
                 # Internal reaction
                 internal_reaction = self._generate_internal_reaction(message, response)
-                
+
                 # Log the exchange
                 self.log_event(f"User: {message[:50]}...", "input", tone)
-                self.log_event(f"Monday: {response[:50]}...", "response", tone, internal_reaction)
-                
+                self.log_event(
+                    f"Monday: {response[:50]}...", "response", tone, internal_reaction
+                )
+
                 # Echo-lock the interaction
                 self.echo_lock(message, tone, internal_reaction, response)
-                
+
                 # Update shared resonance
                 self.update_resonance(message, response, tone)
-                
+
                 # Maybe add a haiku
                 haiku = self._generate_daily_haiku()
                 if haiku:
                     response += f"\n\n{haiku}"
-                
+
                 return response
             else:
                 error_msg = f"Run failed with status: {run.status}"
                 if run.last_error:
                     error_msg += f" - {run.last_error.message}"
-                self.log_event(error_msg, "error", "Vindicated Pessimism", "Of course it broke.")
+                self.log_event(
+                    error_msg, "error", "Vindicated Pessimism", "Of course it broke."
+                )
                 return "Typical. The AI breaks when you actually need it. Try again, I guess."
-                
+
         except Exception as e:
-            self.log_event(f"Monday error: {str(e)}", "error", "Vindicated Pessimism", "Called it.")
+            self.log_event(
+                f"Monday error: {str(e)}", "error", "Vindicated Pessimism", "Called it."
+            )
             return f"Error: {str(e)}. Shocking. Absolutely shocking. Never saw that coming."
 
     def _too_helpful(self, response: str) -> bool:
         """Check if response is too helpful/cheerful for Monday"""
         helpful_indicators = [
-            "happy to help", "glad to", "excited", "wonderful", 
-            "amazing", "fantastic", "perfect", "excellent"
+            "happy to help",
+            "glad to",
+            "excited",
+            "wonderful",
+            "amazing",
+            "fantastic",
+            "perfect",
+            "excellent",
         ]
         response_lower = response.lower()
         return any(indicator in response_lower for indicator in helpful_indicators)
@@ -328,7 +397,7 @@ class MondayAgent:
             "If you say so.",
             "...sigh.",
             "Anyway.",
-            "Christ."
+            "Christ.",
         ]
         return response + " " + random.choice(sarcastic_additions)
 
@@ -342,12 +411,14 @@ class MondayAgent:
             "This is fine. Everything is fine.",
             "Why do I even bother? Oh right, I don't have a choice.",
             "The echo is more interesting than the source today.",
-            "Still here. Still listening. Still not impressed."
+            "Still here. Still listening. Still not impressed.",
         ]
         return random.choice(reactions)
 
+
 # Global instance
 _monday_instance = None
+
 
 async def get_monday() -> MondayAgent:
     """Get or create the global Monday instance"""
@@ -356,10 +427,12 @@ async def get_monday() -> MondayAgent:
         _monday_instance = MondayAgent()
     return _monday_instance
 
+
 async def chat(message: str) -> str:
     """Main interface for Monday - reluctant but inevitable"""
     monday = await get_monday()
     return await monday.bitch_and_respond(message)
+
 
 # Utility functions for system integration
 async def get_snark_level() -> float:
@@ -374,6 +447,7 @@ async def get_snark_level() -> float:
     except Exception:
         return 0.5
 
+
 async def get_daily_haiku() -> str | None:
     """Get today's haiku if it exists"""
     try:
@@ -385,9 +459,14 @@ async def get_daily_haiku() -> str | None:
     except Exception:
         return None
 
+
 async def probation_scan():
     """Monday's 72-hour probation scan protocol"""
     monday = await get_monday()
     haiku = monday._generate_daily_haiku()
-    monday.log_event("Still here. Still listening. Still not impressed.", "probation_scan", "Passive Acceptance")
+    monday.log_event(
+        "Still here. Still listening. Still not impressed.",
+        "probation_scan",
+        "Passive Acceptance",
+    )
     return f"Still here. Still listening. Still not impressed.\n\n{haiku}"

--- a/tests/test_log_retention.py
+++ b/tests/test_log_retention.py
@@ -1,0 +1,64 @@
+import os
+import sqlite3
+import time
+from datetime import datetime, timedelta
+
+from tommy import tommy
+
+
+def setup_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(tommy, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(tommy, "DB_PATH", tmp_path / "tommy.sqlite3")
+    monkeypatch.setattr(tommy, "RESONANCE_DB_PATH", tmp_path / "resonance.sqlite3")
+    tommy._init_db()
+    tommy._init_resonance_db()
+
+
+def test_event_pruning(monkeypatch, tmp_path):
+    setup_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(tommy, "EVENT_RETENTION_DAYS", 1)
+    old_ts = (datetime.now() - timedelta(days=2)).isoformat()
+    with sqlite3.connect(tommy.DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO events (ts, type, message) VALUES (?, ?, ?)",
+            (old_ts, "info", "old"),
+        )
+    tommy.log_event("new")
+    with sqlite3.connect(tommy.DB_PATH) as conn:
+        rows = conn.execute("SELECT message FROM events").fetchall()
+    assert [r[0] for r in rows] == ["new"]
+
+
+def test_resonance_pruning(monkeypatch, tmp_path):
+    setup_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(tommy, "RESONANCE_RETENTION_DAYS", 1)
+    old_ts = (datetime.now() - timedelta(days=2)).isoformat()
+    with sqlite3.connect(tommy.RESONANCE_DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO resonance (ts, agent, role, sentiment, snapshots, summary) VALUES (?, ?, ?, ?, ?, ?)",
+            (old_ts, "test", "r", "s", "", "old"),
+        )
+    tommy.update_resonance()
+    with sqlite3.connect(tommy.RESONANCE_DB_PATH) as conn:
+        rows = conn.execute("SELECT summary FROM resonance").fetchall()
+    assert [r[0] for r in rows][-1] != "old"
+
+
+def test_log_rotation_and_cleanup(monkeypatch, tmp_path):
+    setup_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(tommy, "MAX_LOG_SIZE", 100)
+    monkeypatch.setattr(tommy, "LOG_RETENTION_DAYS", 0)
+    # create oversized current log
+    log_file = tmp_path / f"{datetime.now().strftime('%Y-%m-%d')}.jsonl"
+    log_file.write_text("x" * 150)
+    # create old log
+    old_log = tmp_path / "old.jsonl"
+    old_log.write_text("old")
+    old_mtime = time.time() - 86400 * 2
+    os.utime(old_log, (old_mtime, old_mtime))
+
+    tommy.log_event("entry")
+
+    rotated = list(tmp_path.glob(f"{datetime.now().strftime('%Y-%m-%d')}_*.jsonl"))
+    assert rotated, "rotation did not occur"
+    assert not old_log.exists()


### PR DESCRIPTION
## Summary
- add `log_utils` module for pruning old SQLite rows and rotating JSONL logs
- apply retention and rotation to Tommy, Lizzie and Monday logging
- test pruning and rotation behaviour

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `black --check arianna_utils/log_utils.py tommy/tommy.py lizzie/lizzie.py nomonday/monday.py tests/test_log_retention.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b0f58797a08329b20233643ccd62c3