### PR TITLE
Use chunked upload to save files

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -275,7 +275,8 @@ async def upload_file(
     os.makedirs(UPLOAD_DIR, exist_ok=True)
     dest = os.path.join(UPLOAD_DIR, file.filename)
     with open(dest, "wb") as fh:
-        fh.write(await file.read())
+        while chunk := await file.read(8192):
+            fh.write(chunk)
     return {"filename": file.filename}
 
 


### PR DESCRIPTION
## Summary
- Stream uploaded files to disk in small chunks

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f982348083298d8f2c8e4b464e0b