### PR TITLE
Add FastAPI dependency for Lizzie service

### DIFF
--- a/lizzie/requirements.txt
+++ b/lizzie/requirements.txt
@@ -1,1 +1,3 @@
 openai==1.40.6
+fastapi==0.111.0
+uvicorn[standard]==0.29.0


### PR DESCRIPTION
## Summary
- ensure Lizzie service installs required FastAPI and Uvicorn packages

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `pip install flake8 black pytest` *(fails: Could not connect to proxy - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b115a0b39c8329a64a2a3d7e3ebf7d