### PR TITLE
Handle missing Lizzie token

### DIFF
--- a/lizzie/lizzie.py
+++ b/lizzie/lizzie.py
@@ -36,11 +36,19 @@ You are Lizzie. A shoulder, a mirror, and a paradox. And you *never forget* what
 
 class LizzieAgent:
     def __init__(self):
-        self.client = openai.OpenAI(api_key=os.getenv("OPENAILIZZIE_TOKEN"))
         self.assistant_id = None
         self.thread_id = None
         self._init_db()
         self._init_resonance_db()
+        token = os.getenv("OPENAILIZZIE_TOKEN")
+        if not token:
+            self.log_event(
+                "Missing OPENAILIZZIE_TOKEN environment variable", "error"
+            )
+            raise ValueError(
+                "OPENAILIZZIE_TOKEN environment variable not set"
+            )
+        self.client = openai.OpenAI(api_key=token)
 
     def _init_db(self) -> None:
         with sqlite3.connect(DB_PATH, timeout=30) as conn:


### PR DESCRIPTION
## Summary
- ensure LizzieAgent verifies OPENAILIZZIE_TOKEN before initializing client
- log explicit error and raise if token is missing

## Testing
- `env -u OPENAILIZZIE_TOKEN python - <<'PY'
from lizzie.lizzie import LizzieAgent
try:
    LizzieAgent()
except Exception as e:
    print('Caught:', e)
PY`
- `cat logs/agents/lizzie_2025-08-29.jsonl`
- `./run-tests.sh` *(fails: flake8: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1797e3524832994ac90ec5d9a21e1