### PR TITLE
Return only summary from parser

### DIFF
--- a/arianna_utils/context_neural_processor.py
+++ b/arianna_utils/context_neural_processor.py
@@ -1065,7 +1065,7 @@ async def parse_and_store_file(
     log_event(
         f"Processed {os.path.basename(path)}: tags={tags}, summary={summary[:50]}..., relevance={relevance:.2f} (pulse={pulse:.2f}, quiver={quiver:.2f}, sense={sense:.2f})"
     )
-    return f"{text}\n\nTags: {tags}\nSummary: {summary}\nRelevance: {relevance:.2f}"
+    return f"Tags: {tags}\nSummary: {summary}\nRelevance: {relevance:.2f}"
 
 
 async def create_repo_snapshot(
@@ -1118,8 +1118,8 @@ if __name__ == "__main__":
 
     async def test():
         if args.path:
-            text = await parse_and_store_file(args.path)
-            logger.info(text)
+            result = await parse_and_store_file(args.path)
+            logger.info(result)
         if args.snapshot:
             await create_repo_snapshot()
 

--- a/tests/test_context_processor.py
+++ b/tests/test_context_processor.py
@@ -23,8 +23,7 @@ def test_parse_and_store_file(tmp_path, monkeypatch):
 
     engine = SQLiteVectorStore(tmp_path / "vectors.db")
     result = asyncio.run(cnp.parse_and_store_file(str(sample), engine=engine))
-
-    assert "hello world" in result
+    assert result.startswith("Tags:")
     hits = engine.query_similar(embed_text("hello world"), top_k=1)
     assert hits and "hello world" in hits[0].content
 

--- a/tommy/tommy_logic.py
+++ b/tommy/tommy_logic.py
@@ -211,7 +211,7 @@ async def process_file_with_context(path: str, engine=None) -> str:
     Returns
     -------
     str
-        Full result from ``parse_and_store_file``.
+        Summary and metadata from ``parse_and_store_file``.
     """
 
     from arianna_utils.context_neural_processor import parse_and_store_file


### PR DESCRIPTION
## Summary
- Trim parse_and_store_file return to tags, summary and relevance, dropping raw text
- Adjust Tommy helper and tests for new return format

## Testing
- `./run-tests.sh` *(fails: flake8: command not found)*
- `black --check arianna_utils/context_neural_processor.py tommy/tommy_logic.py tests/test_context_processor.py` *(fails: would reformat arianna_utils/context_neural_processor.py)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_68b179d567f08329b9c7f27ac113f6be