### PR TITLE
Limit vector store content to metadata

### DIFF
--- a/arianna_utils/context_neural_processor.py
+++ b/arianna_utils/context_neural_processor.py
@@ -1047,8 +1047,9 @@ async def parse_and_store_file(
     # Vector store
     try:
         content = (
-            f"FILE {os.path.basename(path)} TAGS: {tags}\n"
-            f"SUMMARY: {summary}\nRELEVANCE: {relevance:.2f}\nTEXT: {text}"
+            f"TAGS: {tags}\n"
+            f"SUMMARY: {summary}\n"
+            f"RELEVANCE: {relevance:.2f}"
         )
         embedding = embed_text(content)
         engine.add_memory("document", content, embedding)


### PR DESCRIPTION
## Summary
- Embed only tags, summary, and relevance when storing documents in vector store

## Testing
- `flake8` *(fails: command not found)*
- `black --check .` *(fails: would reformat 3 files)*
- `pytest` *(fails: No module named 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_68b17bd40ba88329a8dc6c3e6bab7f46