### PR TITLE
Add Telegram bot interface for Lizzie

### DIFF
--- a/lizzie/Procfile
+++ b/lizzie/Procfile
@@ -1,1 +1,2 @@
-web: python lizzie.py
+web: uvicorn lizzie.lizzie:app --host 0.0.0.0 --port ${PORT:-8000}
+bot: python -m lizzie.telegram_bot

--- a/lizzie/requirements.txt
+++ b/lizzie/requirements.txt
@@ -1,3 +1,4 @@
 openai==1.40.6
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
+python-telegram-bot==21.6

--- a/lizzie/telegram_bot.py
+++ b/lizzie/telegram_bot.py
@@ -1,0 +1,42 @@
+"""Telegram bot interface for Lizzie.
+
+This bot relays incoming Telegram messages to the Lizzie agent and
+returns the resonance response.
+"""
+
+import os
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from . import lizzie
+
+
+async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle incoming text messages."""
+
+    if not update.message or not update.message.text:
+        return
+
+    response = await lizzie.chat(update.message.text)
+    await update.message.reply_text(response)
+
+
+def main() -> None:
+    token = os.getenv("TELEGRAM_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+
+    application = ApplicationBuilder().token(token).build()
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, _handle_message)
+    )
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- run Lizzie FastAPI server via uvicorn and launch separate Telegram bot process
- add python-telegram-bot dependency for Lizzie
- implement bot script that relays Telegram messages to Lizzie's resonance engine
- update Telegram bot configuration and Procfile paths for reliable startup

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a matching distribution for uvicorn==0.30.0)*
- `./run-tests.sh` *(fails: flake8: command not found)*
- `black --check lizzie/telegram_bot.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_68b1846ea3688329afc7843cf86ef091